### PR TITLE
Fix: Mismatch of metrics

### DIFF
--- a/powermon-mqtt.sh
+++ b/powermon-mqtt.sh
@@ -11,9 +11,9 @@ MQTT_PW=""
 
 for ct in $(seq 0 5)
 do
-	w=$(influx -database power_monitor -execute "select last(power) from raw_cts where ct = '${ct}' and time > now() - 1m group by power fill(0) limit 1" -format csv |grep ^raw_cts |perl -lpe 's/.*,//; s/(\..).*/$1/; $_=0 if ($_<0);')
+	w=$(influx -database power_monitor -execute "select mean(power) from raw_cts where ct = '${ct}' and time > now() - 1m group by power fill(0) limit 1" -format csv |grep ^raw_cts |perl -lpe 's/.*,//; s/(\..).*/$1/; $_=0 if ($_<0);')
 	mosquitto_pub -u "${MQTT_UN}" -P "${MQTT_PW}" -h "${1}" -t "${PREFIX}/ct_${ct}/power" -m "${w}"
 done
 
-homeload=$(influx -database power_monitor -execute "select last(power) from home_load where time > now() - 1m group by power fill(0) limit 1" -format csv |grep ^home_load |perl -lpe 's/.*,//; s/(\..).*/$1/')
+homeload=$(influx -database power_monitor -execute "select mean(power) from home_load where time > now() - 1m group by power fill(0) limit 1" -format csv |grep ^home_load |perl -lpe 's/.*,//; s/(\..).*/$1/')
 mosquitto_pub -u "${MQTT_UN}" -P "${MQTT_PW}" -h "${1}" -t "${PREFIX}/home_load/power" -m "${homeload}"


### PR DESCRIPTION
### Description

This will correct the mismatch between Home Assistant and HomePower Dashboard (Grafana). Changing the value to a mean of last minute will resolv this.

### Testing

Here is the test I've done.

1. Run the process as-is for 1 day and compare metrics from Home Assistant and HomePower Dashboard (Grafana).
Result: 44.66kWh for HomePower Dashboard vs 44.56kWh for Home Assistant.
<img width="168" alt="Capture d’écran, le 2021-10-21 à 13 23 03" src="https://user-images.githubusercontent.com/45883038/138329547-266b3018-e597-4534-8d29-fc35b1bf1049.png">
<img width="211" alt="Capture d’écran, le 2021-10-21 à 13 23 19" src="https://user-images.githubusercontent.com/45883038/138329553-131700f6-39b4-453d-9ed3-58c2d4f9e459.png">

2. Change the calculation to mean aggregation and run the process for 1 day then compare Home Assistant and HomePower Dashboard (Grafana).
Result: 56.41kWh for HomePower Dashboard vs 56.42kWh for Home Assistant.
<img width="229" alt="Capture d’écran, le 2021-10-11 à 21 08 21" src="https://user-images.githubusercontent.com/45883038/138329507-33c3bf0e-42fb-4a61-892c-03c4555e9583.png">
<img width="168" alt="Capture d’écran, le 2021-10-11 à 21 08 38" src="https://user-images.githubusercontent.com/45883038/138329517-24b297df-e0a4-49e2-b894-77a83d9348b7.png">

### Conclusion

I Would say that this is a pretty good result.

Fix: #4 Mismatch of metrics using Last Power value
